### PR TITLE
Adjust wandering trader conversion mechanics

### DIFF
--- a/data/keehan/advancements/displayed/player_converted_wandering_trader.json
+++ b/data/keehan/advancements/displayed/player_converted_wandering_trader.json
@@ -1,0 +1,19 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:emerald"
+    },
+    "title": "Trusted Supplier",
+    "description": "Convert a wandering trader into a dealer.",
+    "frame": "goal",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "keehan:weedcraft",
+  "criteria": {
+    "conversion": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/keehan/advancements/utils/player_used_blunt_on_wandering_trader.json
+++ b/data/keehan/advancements/utils/player_used_blunt_on_wandering_trader.json
@@ -1,0 +1,19 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:item_used_on_entity",
+      "conditions": {
+        "entity": {
+          "type": "minecraft:wandering_trader"
+        },
+        "item": {
+          "items": ["minecraft:golden_apple"],
+          "nbt": "{Blunt:1b}"
+        }
+      }
+    }
+  },
+  "rewards": {
+    "function": "keehan:weedcraft/generic/drug_dealer_manual_convert"
+  }
+}

--- a/data/keehan/functions/weedcraft/generic/drug_dealer_manual_convert.mcfunction
+++ b/data/keehan/functions/weedcraft/generic/drug_dealer_manual_convert.mcfunction
@@ -1,0 +1,14 @@
+## Convert a wandering trader into a dealer when clicked with a blunt
+    #> Called by the "keehan:utils/player_used_blunt_on_wandering_trader" advancement
+
+    # Mark the closest trader that hasn't been converted yet
+    execute as @e[type=minecraft:wandering_trader,tag=!weedcraft.drug_dealer,sort=nearest,limit=1,distance=..3] run tag @s add weedcraft.manual_conversion_candidate
+
+    # Convert the marked trader into a dealer
+    execute as @e[tag=weedcraft.manual_conversion_candidate] run function keehan:weedcraft/generic/drug_dealer_init
+
+    # Grant the advancement to the player if a trader was successfully converted
+    execute if entity @e[tag=weedcraft.manual_conversion_candidate] run advancement grant @s only keehan:displayed/player_converted_wandering_trader
+
+    # Clean up the temporary tag
+    execute as @e[tag=weedcraft.manual_conversion_candidate] run tag @s remove weedcraft.manual_conversion_candidate

--- a/data/keehan/functions/weedcraft/generic/drug_dealer_tick.mcfunction
+++ b/data/keehan/functions/weedcraft/generic/drug_dealer_tick.mcfunction
@@ -1,4 +1,4 @@
 ## Handle the wandering drug dealer conversion logic
     #> Called by the "keehan:weedcraft/main" function every tick
 
-    execute as @e[type=minecraft:wandering_trader,tag=!weedcraft.drug_dealer] run function keehan:weedcraft/generic/drug_dealer_init
+    execute as @e[type=minecraft:wandering_trader,tag=!weedcraft.drug_dealer,sort=random,limit=1] if predicate keehan:drug_dealer_conversion_chance run function keehan:weedcraft/generic/drug_dealer_init

--- a/data/keehan/predicates/drug_dealer_conversion_chance.json
+++ b/data/keehan/predicates/drug_dealer_conversion_chance.json
@@ -1,0 +1,4 @@
+{
+  "condition": "minecraft:random_chance",
+  "chance": 0.0002
+}


### PR DESCRIPTION
## Summary
- add a low random chance predicate so only one wandering trader converts into a dealer at a time
- enable manual wandering trader conversion by using a blunt, granting a visible advancement on success
- introduce helper function and advancements to drive the manual conversion flow

## Testing
- not run (datapack changes)


------
https://chatgpt.com/codex/tasks/task_e_68d7a3b1937c832fa4fa129eb980e490