### PR TITLE
Switch dealer conversion item and add utility commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ When crafted, these recipes output a temporary knowledge book which the datapack
 ### Resource Drops
 
 * **Bottled Amethyst** – Harvest amethyst clusters with the Chisel to bottle concentrated amethyst.
-* **Weed** – Use Loppers on large ferns to collect custom Weed and extra ferns.
+* **Weed** – Use Loppers on large ferns to collect custom Weed and Weed Plants for replanting.
 * **Red & Brown Shredded Shrooms** – Clip mushrooms with Loppers for shredded components.
 * **Coca Leaves** – Cut fully grown cocoa pods with the Pruning Machete.
 
@@ -52,3 +52,10 @@ Advancements track crafting each consumable and reward a final goal for making e
 Use this reference to plan your farm, schedule your highs carefully, and avoid the fatal combination!
 
 ![Basic Instructions](https://i.imgur.com/ajpdfXu.png)
+
+## Utility Commands
+
+Run these functions directly (e.g. `/function keehan:weedcraft/commands/spawn_drug_dealer`) to assist with testing or creative setups:
+
+* `keehan:weedcraft/commands/spawn_drug_dealer` – Summons a wandering trader and immediately configures them as a drug dealer.
+* `keehan:weedcraft/commands/give_field_guide` – Gives the Weedcraft Field Guide sold by the dealer.

--- a/data/keehan/advancements/utils/player_used_weed_plant_on_wandering_trader.json
+++ b/data/keehan/advancements/utils/player_used_weed_plant_on_wandering_trader.json
@@ -7,8 +7,10 @@
           "type": "minecraft:wandering_trader"
         },
         "item": {
-          "items": ["minecraft:golden_apple"],
-          "nbt": "{Blunt:1b}"
+          "items": [
+            "minecraft:fern"
+          ],
+          "nbt": "{WeedPlant:1b}"
         }
       }
     }

--- a/data/keehan/functions/weedcraft/commands/give_field_guide.mcfunction
+++ b/data/keehan/functions/weedcraft/commands/give_field_guide.mcfunction
@@ -1,0 +1,4 @@
+## Give the Weedcraft Field Guide to the executor
+    #> Utility command similar to the recipe give commands
+
+    loot give @s loot keehan:misc/weedcraft_field_guide

--- a/data/keehan/functions/weedcraft/commands/spawn_drug_dealer.mcfunction
+++ b/data/keehan/functions/weedcraft/commands/spawn_drug_dealer.mcfunction
@@ -1,0 +1,11 @@
+## Spawn a wandering drug dealer at the executor's location
+    #> Utility command similar to the recipe give commands
+
+    # Summon a fresh wandering trader with a temporary tag
+    summon minecraft:wandering_trader ~ ~ ~ {Tags:["weedcraft.spawn_candidate"]}
+
+    # Initialize the summoned trader as a drug dealer
+    execute as @e[type=minecraft:wandering_trader,tag=weedcraft.spawn_candidate,limit=1,sort=nearest] run function keehan:weedcraft/generic/drug_dealer_init
+
+    # Remove the temporary tag now that initialization is complete
+    execute as @e[type=minecraft:wandering_trader,tag=weedcraft.spawn_candidate] run tag @s remove weedcraft.spawn_candidate

--- a/data/keehan/functions/weedcraft/generic/drug_dealer_manual_convert.mcfunction
+++ b/data/keehan/functions/weedcraft/generic/drug_dealer_manual_convert.mcfunction
@@ -1,5 +1,5 @@
-## Convert a wandering trader into a dealer when clicked with a blunt
-    #> Called by the "keehan:utils/player_used_blunt_on_wandering_trader" advancement
+## Convert a wandering trader into a dealer when clicked with a weed plant
+    #> Called by the "keehan:utils/player_used_weed_plant_on_wandering_trader" advancement
 
     # Mark the closest trader that hasn't been converted yet
     execute as @e[type=minecraft:wandering_trader,tag=!weedcraft.drug_dealer,sort=nearest,limit=1,distance=..3] run tag @s add weedcraft.manual_conversion_candidate

--- a/data/keehan/loot_tables/drugs/weed.json
+++ b/data/keehan/loot_tables/drugs/weed.json
@@ -35,6 +35,19 @@
                             "function": "minecraft:set_count",
                             "count": 2.0,
                             "add": false
+                        },
+                        {
+                            "function": "minecraft:set_name",
+                            "name": {
+                                "bold": false,
+                                "italic": false,
+                                "color": "dark_green",
+                                "text": "Weed Plant"
+                            }
+                        },
+                        {
+                            "function": "minecraft:set_nbt",
+                            "tag": "{WeedPlant:1b}"
                         }
                     ]
                 }

--- a/data/keehan/loot_tables/misc/weedcraft_field_guide.json
+++ b/data/keehan/loot_tables/misc/weedcraft_field_guide.json
@@ -1,0 +1,19 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "minecraft:written_book",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_nbt",
+                            "tag": "{title:\"Weedcraft Field Guide\",author:\"The Green Hand\",resolved:1b,generation:0,pages:[\"{\\\"text\\\": \\\"\\\", \\\"extra\\\": [{\\\"text\\\": \\\"Weedcraft Field Guide\\\", \\\"bold\\\": true, \\\"color\\\": \\\"dark_green\\\"}, {\\\"text\\\": \\\"\\\\n\\\\nThese notes were copied from a dealer's ledger. Treat them with care and don't let the guards see the cover.\\\", \\\"color\\\": \\\"black\\\"}]}\", \"{\\\"text\\\": \\\"\\\", \\\"extra\\\": [{\\\"text\\\": \\\"Blunt\\\", \\\"bold\\\": true, \\\"color\\\": \\\"green\\\"}, {\\\"text\\\": \\\"\\\\nRecipe: Jigsaw + Paper + Magma Cream.\\\", \\\"color\\\": \\\"black\\\"}, {\\\"text\\\": \\\"\\\\nEffects: A dizzy ride of levitation, blindness, nausea, and a heavy crash of resistance, hunger, slowness, slow falling, and mining fatigue.\\\", \\\"color\\\": \\\"dark_gray\\\"}]}\", \"{\\\"text\\\": \\\"\\\", \\\"extra\\\": [{\\\"text\\\": \\\"Cocaine\\\", \\\"bold\\\": true, \\\"color\\\": \\\"white\\\"}, {\\\"text\\\": \\\"\\\\nRecipe: Repeating Command Block + Sugar + Charcoal.\\\", \\\"color\\\": \\\"black\\\"}, {\\\"text\\\": \\\"\\\\nEffects: Blinding rush with speed, haste, jump boost, but the unluck and wither bite back hard.\\\", \\\"color\\\": \\\"dark_gray\\\"}]}\", \"{\\\"text\\\": \\\"\\\", \\\"extra\\\": [{\\\"text\\\": \\\"Meth\\\", \\\"bold\\\": true, \\\"color\\\": \\\"aqua\\\"}, {\\\"text\\\": \\\"\\\\nRecipe: Command Block + Gunpowder + Bone Meal.\\\", \\\"color\\\": \\\"black\\\"}, {\\\"text\\\": \\\"\\\\nEffects: Buzzing strength, night vision, and a glow that won't hide you, paired with nausea and poison tremors.\\\", \\\"color\\\": \\\"dark_gray\\\"}]}\", \"{\\\"text\\\": \\\"\\\", \\\"extra\\\": [{\\\"text\\\": \\\"Mixed Shrooms\\\", \\\"bold\\\": true, \\\"color\\\": \\\"light_purple\\\"}, {\\\"text\\\": \\\"\\\\nRecipe: Chain Command Block + Structure Block + Nether Wart.\\\", \\\"color\\\": \\\"black\\\"}, {\\\"text\\\": \\\"\\\\nEffects: Nausea blooms into luck, night sight, regeneration, saturation, and a strange weakness in the limbs.\\\", \\\"color\\\": \\\"dark_gray\\\"}]}\", \"{\\\"text\\\": \\\"\\\", \\\"extra\\\": [{\\\"text\\\": \\\"Journal\\\", \\\"bold\\\": true, \\\"color\\\": \\\"dark_purple\\\"}, {\\\"text\\\": \\\"\\\\nTried every blend in one long night. The world rang like copper and my heart simply stopped. I woke up elsewhere, missing minutes I can't account for. Whatever really happens, I'm not writing it down here.\\\", \\\"color\\\": \\\"black\\\"}]}\"]}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- require the weed plant item to manually convert wandering traders into dealers
- tag weed plant drops so they can trigger the conversion and document the change
- add utility functions to spawn a dealer or obtain the field guide book for testing

## Testing
- not run (datapack changes)


------
https://chatgpt.com/codex/tasks/task_e_68da65bcf528832fad28126052a055ad