### PR TITLE
Require weed item for manual wandering trader conversion

### DIFF
--- a/data/keehan/advancements/utils/player_used_weed_plant_on_wandering_trader.json
+++ b/data/keehan/advancements/utils/player_used_weed_plant_on_wandering_trader.json
@@ -8,9 +8,9 @@
         },
         "item": {
           "items": [
-            "minecraft:fern"
+            "minecraft:jigsaw"
           ],
-          "nbt": "{WeedPlant:1b}"
+          "nbt": "{Weed:1b}"
         }
       }
     }

--- a/data/keehan/functions/weedcraft/generic/drug_dealer_manual_convert.mcfunction
+++ b/data/keehan/functions/weedcraft/generic/drug_dealer_manual_convert.mcfunction
@@ -1,4 +1,4 @@
-## Convert a wandering trader into a dealer when clicked with a weed plant
+## Convert a wandering trader into a dealer when clicked with the weed item
     #> Called by the "keehan:utils/player_used_weed_plant_on_wandering_trader" advancement
 
     # Mark the closest trader that hasn't been converted yet


### PR DESCRIPTION
## Summary
- update the manual conversion advancement to look for the weed jigsaw item instead of the weed plant
- refresh the manual conversion documentation comment to match the new trigger

## Testing
- not run (datapack change)


------
https://chatgpt.com/codex/tasks/task_e_68da7c3c6330832f9336d091a45c7e20