### PR TITLE
Update datapack for 1.21.8 and allow drug-based trader conversion

### DIFF
--- a/data/keehan/advancements/utils/player_used_weed_plant_on_wandering_trader.json
+++ b/data/keehan/advancements/utils/player_used_weed_plant_on_wandering_trader.json
@@ -1,6 +1,6 @@
 {
   "criteria": {
-    "requirement": {
+    "weed": {
       "trigger": "minecraft:item_used_on_entity",
       "conditions": {
         "entity": {
@@ -13,8 +13,73 @@
           "nbt": "{Weed:1b}"
         }
       }
+    },
+    "blunt": {
+      "trigger": "minecraft:item_used_on_entity",
+      "conditions": {
+        "entity": {
+          "type": "minecraft:wandering_trader"
+        },
+        "item": {
+          "items": [
+            "minecraft:golden_apple"
+          ],
+          "nbt": "{Blunt:1b}"
+        }
+      }
+    },
+    "cocaine": {
+      "trigger": "minecraft:item_used_on_entity",
+      "conditions": {
+        "entity": {
+          "type": "minecraft:wandering_trader"
+        },
+        "item": {
+          "items": [
+            "minecraft:golden_apple"
+          ],
+          "nbt": "{Cocaine:1b}"
+        }
+      }
+    },
+    "meth": {
+      "trigger": "minecraft:item_used_on_entity",
+      "conditions": {
+        "entity": {
+          "type": "minecraft:wandering_trader"
+        },
+        "item": {
+          "items": [
+            "minecraft:golden_apple"
+          ],
+          "nbt": "{Meth:1b}"
+        }
+      }
+    },
+    "mixed_shrooms": {
+      "trigger": "minecraft:item_used_on_entity",
+      "conditions": {
+        "entity": {
+          "type": "minecraft:wandering_trader"
+        },
+        "item": {
+          "items": [
+            "minecraft:golden_apple"
+          ],
+          "nbt": "{MixedShrooms:1b}"
+        }
+      }
     }
   },
+  "requirements": [
+    [
+      "weed",
+      "blunt",
+      "cocaine",
+      "meth",
+      "mixed_shrooms"
+    ]
+  ],
   "rewards": {
     "function": "keehan:weedcraft/generic/drug_dealer_manual_convert"
   }

--- a/data/keehan/functions/weedcraft/generic/drug_dealer_manual_convert.mcfunction
+++ b/data/keehan/functions/weedcraft/generic/drug_dealer_manual_convert.mcfunction
@@ -1,4 +1,4 @@
-## Convert a wandering trader into a dealer when clicked with the weed item
+## Convert a wandering trader into a dealer when clicked with a custom drug item
     #> Called by the "keehan:utils/player_used_weed_plant_on_wandering_trader" advancement
 
     # Mark the closest trader that hasn't been converted yet

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
-        "pack_format": 48,
+        "pack_format": 58,
         "description": "\"Important Tweaks\", a datapack by Keehan & Keehan"
     }
 }


### PR DESCRIPTION
## Summary
- raise the datapack pack_format to 58 for Minecraft 1.21.8 compatibility
- allow the wandering trader conversion advancement to trigger with any custom drug item and document the behaviour in-code

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dae7601d10832f92664ee7d57f44e8